### PR TITLE
Auto-locate files to load in dev server, fix static build, expand documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ or copy this code into your plugin:
 ```php
 require __DIR__ . '/loader.php';
 
-add_action( 'wp_enqueue_scripts', 'ReactWPScripts\\autoenqueue_theme_assets' );
+add_action( 'wp_enqueue_scripts', 'ReactWPScripts\\autoenqueue_plugin_assets' );
 ```
 
 This will load all generated JS and CSS into your theme or plugin.

--- a/README.md
+++ b/README.md
@@ -52,12 +52,10 @@ This will load all generated JS and CSS into your theme or plugin.
 
 The `enqueue_assets` function takes two arguments: the filesystem path to the project directory containing the `src` and `build` folders, and an optional array argument which may be used to customize script handles and dependencies. Available options:
 
-- `base_url`: The URL of the project base that contains the `src` and `build` directories.
+- `base_url`: The URL of the project base that contains the `src` and `build` directories. If not specified, this URL will be inferred from the provided directory path string.
 - `handle`: The handle to use when registering the app's script and stylesheet. This will default to the last part of the directory passed to enqueue_assets.
 - `scripts`: An array of script dependencies to load before your bundle.
 - `styles`: An array of stylesheet dependencies to load before your bundle.
-
-As in the examples above, for proper script resolution within a theme or plugin the `base_url` property is effectively required.
 
 ## How It Works
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ Finally, the PHP in `loader.php` uses the location of the generated `assets-mani
 
 ## Troubleshooting
 
+### Server will not start
+
 If the development server will not start or WordPress is showing script errors, try deleting the `assets-manifest.json` in the project root then re-start the development server.
 
+### Scripts do not load
+
 If the development server is not running, the root `assets-manifest.json` is not present, and scripts still will not load, re-run `npm run build` to re-generate any build assets that may be missing.
+
+### Fatal Error: Cannot redeclare ReactWPScripts...
+
+If you get an error that you cannot reduplicate a method in the `ReactWPScripts` namespace, the cause is likely that two copies of `loader.php` are present in separate plugins or themes. Switch the copy in the plugin or theme under development to use a different namespace to avoid collision.

--- a/README.md
+++ b/README.md
@@ -1,25 +1,36 @@
 # react-wp-scripts
 
-A wrapper for create-react-app's react-scripts to allow seamless usage in a theme (and maybe plugins in the future?).
+A wrapper for create-react-app's `react-scripts` to allow seamless usage of scripts and styles served from `webpack-dev-server` while developing a theme or plugin.
 
-**Do not use this.**
+**Important Note**: This project is brand new, and largely untested. We recommend using it as a learning tool rather than depending on it for critical development work.
 
-## Usage
+## Installation & Usage
 
-Add as a package from git, then change your `start` script in `package.json` to:
+From the root directory of your `create-react-app`-generated project, run
+
+```sh
+npm install humanmade/react-wp-scripts
+```
+
+Once installed, change your `start` script in `package.json` from
 
 ```
-react-wp-scripts start
+"start": "react-scripts start",
+```
+to
+```
+"start": "react-wp-scripts start",
 ```
 
-Copy `loader.php` to your WP project, and add the loader file:
+Copy `loader.php` to your project (_e.g._ `cp node_modules/react-wp-scripts/loader.php .` on OSX/Linux), then copy this code into your theme or plugin:
 
 ```php
 require __DIR__ . '/loader.php';
 
-add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\enqueue_assets' );
-
 function enqueue_assets() {
-	\ReactWPScripts\enqueue_assets( 'nameoftheme', [ 'any',  'dependencies' ] );
+	\ReactWPScripts\enqueue_assets( 'nameoftheme', [ 'any', 'dependencies' ] );
 }
+add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\enqueue_assets' );
 ```
+
+This will enqueue `http://localhost:[active port]/static/js/bundle.js` to load in your theme or plugin.

--- a/README.md
+++ b/README.md
@@ -22,21 +22,42 @@ to
 "start": "react-wp-scripts start",
 ```
 
-Copy `loader.php` to your project (_e.g._ `cp node_modules/react-wp-scripts/loader.php .` on OSX/Linux), then copy this code into your theme:
+Copy `loader.php` from the module to your project root (_e.g._ `cp node_modules/react-wp-scripts/loader.php .` on OSX/Linux), then copy this code into your theme:
 
 ```php
 require __DIR__ . '/loader.php';
 
-add_action( 'wp_enqueue_scripts', 'ReactWPScripts\\autoenqueue_theme_assets' );
+function mytheme_enqueue_assets() {
+	\ReactWPScripts\enqueue_assets( get_stylesheet_directory(), [
+		'base_url' => get_stylesheet_directory_uri(),
+	] );
+}
+add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\enqueue_assets' );
 ```
 or copy this code into your plugin:
 ```php
 require __DIR__ . '/loader.php';
 
-add_action( 'wp_enqueue_scripts', 'ReactWPScripts\\autoenqueue_plugin_assets' );
+function myplugin_enqueue_assets() {
+	\ReactWPScripts\enqueue_assets( plugin_dir_path( __FILE__ ), [
+		'base_url' => plugin_dir_url( __FILE__ ),
+	] );
+}
+add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\enqueue_assets' );
 ```
 
 This will load all generated JS and CSS into your theme or plugin.
+
+### `enqueue_assets`
+
+The `enqueue_assets` function takes two arguments: the filesystem path to the project directory containing the `src` and `build` folders, and an optional array argument which may be used to customize script handles and dependencies. Available options:
+
+- `base_url`: The URL of the project base that contains the `src` and `build` directories.
+- `handle`: The handle to use when registering the app's script and stylesheet. This will default to the last part of the directory passed to enqueue_assets.
+- `scripts`: An array of script dependencies to load before your bundle.
+- `styles`: An array of stylesheet dependencies to load before your bundle.
+
+As in the examples above, for proper script resolution within a theme or plugin the `base_url` property is effectively required.
 
 ## How It Works
 

--- a/loader.php
+++ b/loader.php
@@ -15,45 +15,121 @@ function is_development() {
 }
 
 /**
- * Get the port for React's development server.
+ * Create a probably-unique key for a given script bundle.
  *
- * @return int|null Port number if available, otherwise null.
+ * @param string $path A relative filesystem path or resource URI.
+ * @return string
  */
-function get_react_port() {
-	if ( ! is_development() ) {
-		return null;
-	}
-
-	$path = get_theme_file_path( 'react-port' );
-	if ( ! file_exists( $path ) ) {
-		return null;
-	}
-
-	$port = file_get_contents( $path );
-	if ( empty( $port ) || ! is_numeric( $port ) ) {
-		return null;
-	}
-
-	return (int) trim( $port );
+function get_asset_key( string $path ) {
+	$path_parts = explode( '/', $path );
+	return 'react_wp_script_' . end( $path_parts );
 }
 
-function enqueue_assets( $id, $deps = [] ) {
-	$port = get_react_port();
-	if ( $port ) {
-		wp_enqueue_script(
-			$id,
-			sprintf( 'http://localhost:%d/static/js/bundle.js', $port ),
-			$deps,
-			null,
-			true
-		);
-	} else {
-		wp_enqueue_script(
-			$id,
-			get_theme_file_uri( 'build/js/main.js' ),
-			$deps,
-			null,
-			true
-		);
+/**
+ * Convert a relative path within a theme or plugin to an absolute filesystem path.
+ *
+ * @param string $path     A relative file system path.
+ * @param bool   $is_theme Whether to treat the $path as a theme file.
+ * @return string;
+ */
+function get_file_path( string $path, bool $is_theme ) {
+	return $is_theme
+		? get_theme_file_path( $path )
+		: plugin_dir_path( __file__ ) . $path;
+}
+
+/**
+ * Check the filesystem for asset manifests for a theme or plugin and attempt to
+ * decode and return the asset list JSON if found.
+ *
+ * @param bool $is_theme Whether to look for the manifest in a theme or plugin context.
+ * @return array|null;
+ */
+function get_assets_list( string $is_theme ) {
+	if ( is_development() ) {
+		$dev_assets_path = get_file_path( 'asset-manifest.json', $is_theme );
+		if ( file_exists( $dev_assets_path ) ) {
+			$build_assets_contents = file_get_contents( $dev_assets_path );
+			if ( ! empty( $build_assets_contents ) ) {
+				return json_decode( file_get_contents( $dev_assets_path ), true );
+			}
+		}
 	}
+	$build_assets_path = get_file_path( 'build/asset-manifest.json', $is_theme );
+	if ( file_exists( $build_assets_path ) ) {
+		$build_assets_contents = file_get_contents( $build_assets_path );
+		if ( ! empty( $build_assets_contents ) ) {
+			return json_decode( file_get_contents( $build_assets_path ), true );
+		}
+	}
+	return null;
+}
+
+
+/**
+ * Return web URIs or convert relative filesystem paths to absolute paths.
+ *
+ * @param string $asset_path  A relative filesystem path or resource URI.
+ * @param bool   $is_theme    Whether to treat the $path as a theme file.
+ * @return string
+ */
+function get_asset_uri( string $asset_path, bool $is_theme ) {
+	if ( strpos( $asset_path, '://' ) !== false ) {
+		return $asset_path;
+	}
+	return $is_theme
+		? get_theme_file_uri( $asset_path )
+		: plugin_dir_url( __file__ ) . $asset_path;
+}
+
+/**
+ * Search for webpack-manifest-plugin output, attempt to load it, and enqueue
+ * any scripts or styles contained within.
+ *
+ * @param bool $is_theme Whether to look for files in a theme or plugin context.
+ */
+function autoenqueue_assets( bool $is_theme ) {
+	// Attempt to load
+	$assets = get_assets_list( $is_theme );
+	if ( empty( $assets ) ) {
+		// TODO: needs error condition.
+		return;
+	}
+
+	foreach ( $assets as $key => $asset_path ) {
+		$is_js = preg_match( '/\.js$/', $asset_path );
+		$is_css = preg_match( '/\.css$/', $asset_path );
+		if ( ! $is_js && ! $is_css ) {
+			continue;
+		}
+		// Asset file contains URIs, enqueue them directly.
+		if ( $is_js ) {
+			wp_enqueue_script(
+				get_asset_key( $asset_path ),
+				get_asset_uri( $asset_path, $is_theme ),
+				[],
+				null,
+				true
+			);
+		} else if ( $is_css ) {
+			wp_enqueue_style(
+				get_asset_key( $asset_path ),
+				get_asset_uri( $asset_path, $is_theme )
+			);
+		}
+	}
+}
+
+/**
+ * Wrapper function to auto-enqueue all built assets for a theme.
+ */
+function autoenqueue_theme_assets() {
+	autoenqueue_assets( true );
+}
+
+/**
+ * Wrapper function to auto-enqueue all built assets for a plugin.
+ */
+function autoenqueue_plugin_assets() {
+	autoenqueue_assets( false );
 }

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -3,22 +3,24 @@ const { spawn } = require( 'child_process' );
 const fs = require( 'fs' );
 const path = require( 'path' );
 const onExit = require( 'signal-exit' );
+const overrideConfigCache = require( './override-start' );
 
 const {
-  choosePort,
-  createCompiler,
-  prepareProxy,
-  prepareUrls,
+	choosePort,
+	createCompiler,
+	prepareProxy,
+	prepareUrls,
 } = require('react-dev-utils/WebpackDevServerUtils');
 
 const DEFAULT_PORT = parseInt(process.env.PORT, 10) || 3000;
 const HOST = process.env.HOST || '0.0.0.0';
 
-const PORT_FILE = path.join( process.cwd(), 'react-port' );
+const ASSET_FILENAME = 'asset-manifest.json'
+const ASSET_FILE_PATH = path.join( process.cwd(), ASSET_FILENAME );
 
-fs.readFile( PORT_FILE, ( err, data ) => {
+fs.readFile( ASSET_FILE_PATH, ( err, data ) => {
 	if ( ! err ) {
-		console.log( chalk.green( `Already running on port ${ data }` ) );
+		console.log( chalk.green( `${ ASSET_FILENAME } found: assuming dev server is already running.` ) );
 		return;
 	}
 
@@ -27,30 +29,18 @@ fs.readFile( PORT_FILE, ( err, data ) => {
 			// We have not found a port.
 			return;
 		}
+		const protocol = process.env.HTTPS === 'true' ? 'https' : 'http';
 
-		try {
-			fs.writeFileSync( PORT_FILE, port );
-		} catch ( err ) {
-			console.log( chalk.red( `Unable to write port to ${ PORT_FILE }` ) );
-			return;
-		}
+		// Pass in the full hostname of the dev server.
+		overrideConfigCache( `${ protocol }://${ HOST }:${ port }` );
 
-		const overridePath = require.resolve( './override-start' );
-		const env = {
-			PORT:    port,
-			BROWSER: 'none',
-		};
-		const opts = {
-			env:   Object.assign( {}, process.env, env ),
-			stdio: 'inherit',
-		};
-		const proc = spawn(
-			process.execPath,
-			[ overridePath ],
-			opts
-		);
+		// Pass the selected port forward so that react-scripts' start will not re-prompt.
+		process.env.PORT = port;
+
+		// Load the parent start script now that configuration patching is complete.
+		require( 'react-scripts/scripts/start' );
 
 		// Before exit, delete the port file.
-		onExit( code => fs.unlinkSync( PORT_FILE ) );
+		onExit( () => fs.unlinkSync( ASSET_FILE_PATH ) );
 	} );
 } );

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -36,6 +36,8 @@ fs.readFile( ASSET_FILE_PATH, ( err, data ) => {
 
 		// Pass the selected port forward so that react-scripts' start will not re-prompt.
 		process.env.PORT = port;
+		// Do not attempt to load the dev server root in a new browser window.
+		process.env.BROWSER = 'none';
 
 		// Load the parent start script now that configuration patching is complete.
 		require( 'react-scripts/scripts/start' );


### PR DESCRIPTION
As I prepare for WCUS I compared this to my previous Webpack dev server integration experiments and noticed that it didn't properly load built files when the dev server wasn't running. `react-scripts` uses the `webpack-manifest-plugin` to generate an assets manifest while running the build task, which we can digest to load all generated CSS and JS. This is a naive approach but satisfies the general use-case where all exported assets are intended to be loaded.

I've expanded the existing override wrapper for the `start` task to use the same plugin in development mode, as it can be configured to output an assets file even when used with `webpack-dev-server`. This let me expand the PHP in this repo to load the development server _or_ built files, depending on which manifest is available (and therefore whether the dev server or built code should be used).

For the time being I have removed the commented-out CSS code and attempted to clean up the PHP for consideration as a released package; it's early days but I would like to get this out there to help us (and other teams) use the project. It could use some good code review first, though :)

As I've worked through this I've updated the documentation with code comments, a conceptual walk-through in the README, and updated installation steps.