### PR TITLE
Wrong dev manifest loading

### DIFF
--- a/loader.php
+++ b/loader.php
@@ -41,7 +41,7 @@ function load_asset_file( $path ) {
 function get_assets_list( string $directory ) {
 	$directory = trailingslashit( $directory );
 	if ( is_development() ) {
-		$dev_assets = load_asset_file( $directory . 'asset-manifest.json' );
+		$dev_assets = load_asset_file( $directory . 'build/asset-manifest.json' );
 		// Fall back to build directory if there is any error loading the development manifest.
 		if ( ! empty( $dev_assets ) ) {
 			return array_values( $dev_assets );

--- a/loader.php
+++ b/loader.php
@@ -113,8 +113,6 @@ function enqueue_assets( $directory, $opts = [] ) {
 	$defaults = [
 		'base_url' => '',
 		'handle'   => basename( $directory ),
-		'scripts'  => [],
-		'styles'   => [],
 	];
 
 	$opts = wp_parse_args( $opts, $defaults );


### PR DESCRIPTION
In development mode, the `asset-manifest.json` is located in the `build` folder but the code was trying to load a file at the root folder.