### PR TITLE
Cache busting version string on built assets

### DIFF
--- a/loader.php
+++ b/loader.php
@@ -115,6 +115,7 @@ function enqueue_assets( $directory, $opts = [] ) {
 		'handle'   => basename( $directory ),
 		'scripts'  => [],
 		'styles'   => [],
+		'version'  => null,
 	];
 
 	$opts = wp_parse_args( $opts, $defaults );
@@ -135,15 +136,16 @@ function enqueue_assets( $directory, $opts = [] ) {
 	foreach ( $assets as $asset_path ) {
 		$is_js   = preg_match( '/\.js$/', $asset_path );
 		$is_css  = preg_match( '/\.css$/', $asset_path );
-		$version = null;
 
 		if ( ! $is_js && ! $is_css ) {
 			// Assets such as source maps and images are also listed; ignore these.
 			continue;
 		}
 
-		if ( file_exists( trailingslashit( $directory ) . $asset_path ) ) {
+		if ( ! $opts['version'] && file_exists( trailingslashit( $directory ) . $asset_path ) ) {
 			$version = filemtime( trailingslashit( $directory ) . $asset_path );
+		} else {
+			$version = $opts['version'];
 		}
 
 		if ( $is_js ) {

--- a/loader.php
+++ b/loader.php
@@ -133,12 +133,17 @@ function enqueue_assets( $directory, $opts = [] ) {
 
 	// There will be at most one JS and one CSS file in vanilla Create React App manifests.
 	foreach ( $assets as $asset_path ) {
-		$is_js = preg_match( '/\.js$/', $asset_path );
-		$is_css = preg_match( '/\.css$/', $asset_path );
+		$is_js   = preg_match( '/\.js$/', $asset_path );
+		$is_css  = preg_match( '/\.css$/', $asset_path );
+		$version = null;
 
 		if ( ! $is_js && ! $is_css ) {
 			// Assets such as source maps and images are also listed; ignore these.
 			continue;
+		}
+
+		if ( file_exists( trailingslashit( $directory ) . $asset_path ) ) {
+			$version = filemtime( trailingslashit( $directory ) . $asset_path );
 		}
 
 		if ( $is_js ) {
@@ -146,13 +151,15 @@ function enqueue_assets( $directory, $opts = [] ) {
 				$opts['handle'],
 				get_asset_uri( $asset_path, $base_url ),
 				[],
-				null,
+				$version,
 				true
 			);
 		} else if ( $is_css ) {
 			wp_enqueue_style(
 				$opts['handle'],
-				get_asset_uri( $asset_path, $base_url )
+				get_asset_uri( $asset_path, $base_url ),
+				[],
+				$version
 			);
 		}
 	}


### PR DESCRIPTION
We really need to change the version string with each release to ensure all the caches are busted as we have pretty aggressive caching with our CDN.

This PR ads the ability to pass a version as an option to `enqueue_assets`. 
If nothing is passed, and the file exsits, then set it to the last modified time of the file.
Else, defaults to `null`.