### PR TITLE
Created init.js script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# dependencies
+/node_modules
+
+# misc
+.DS_Store
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/README.md
+++ b/README.md
@@ -1,48 +1,28 @@
 # react-wp-scripts
 
-A wrapper for create-react-app's `react-scripts` to allow seamless usage of scripts and styles served from `webpack-dev-server` while developing a theme or plugin.
+A wrapper for create-react-app's [`react-scripts`](https://github.com/facebookincubator/create-react-app/tree/master/packages/react-scripts) to allow seamless usage of scripts and styles served from `webpack-dev-server` while developing a theme or plugin.
 
 **Important Note**: This project is brand new, and largely untested. We recommend using it as a learning tool rather than depending on it for critical development work.
 
 ## Installation & Usage
 
-From the root directory of your `create-react-app`-generated project, run
+Run `create-react-app --scripts-version react-wp-scripts /path/to/your/project/folder`
 
-```sh
-npm install react-wp-scripts
-```
+A new `loader-react-scripts.php` will be created on your generated project folder.
 
-Once installed, change your `start` script in `package.json` from
-
-```
-"start": "react-scripts start",
-```
-to
-```
-"start": "react-wp-scripts start",
-```
-
-Copy `loader.php` from the module to your project root (_e.g._ `cp node_modules/react-wp-scripts/loader.php .` on OSX/Linux), then copy this code into your theme:
-
+Copy this code into your theme/plugin:
 ```php
-require __DIR__ . '/loader.php';
+require __DIR__ . '/loader-react-scripts.php';
 
 function mytheme_enqueue_assets() {
 	\ReactWPScripts\enqueue_assets( get_stylesheet_directory() );
 }
 add_action( 'wp_enqueue_scripts', 'mytheme_enqueue_assets' );
 ```
-or copy this code into your plugin:
-```php
-require __DIR__ . '/loader.php';
-
-function myplugin_enqueue_assets() {
-	\ReactWPScripts\enqueue_assets( plugin_dir_path( __FILE__ ) );
-}
-add_action( 'wp_enqueue_scripts', 'myplugin_enqueue_assets' );
-```
 
 This will load all generated JS and CSS into your theme or plugin.
+
+From now on, follow the common `react-scripts` [commands](https://github.com/facebookincubator/create-react-app/blob/master/README.md#npm-start-or-yarn-start)
 
 ### `enqueue_assets`
 

--- a/README.md
+++ b/README.md
@@ -6,35 +6,29 @@ A wrapper for create-react-app's [`react-scripts`](https://github.com/facebookin
 
 ## Installation & Usage
 
-Run `create-react-app --scripts-version react-wp-scripts --php-namespace="Your_Namespace" /path/to/your/project/folder`
-Replace `Your_Namespace` with any name you'd like to use for your PHP namespace. Default is `ReactWPScripts`
+Run `create-react-app --scripts-version react-wp-scripts --php-namespace="Your_Namespace" /path/to/your/project/folder` to generate a new create-react-app project configured to use these custom scripts.
 
-A new `react-wp-scripts.php` will be created on your generated project folder.
+The file `react-wp-scripts.php` will be created within your generated project folder. Replace `Your_Namespace` with the PHP namespace you would like to use for this file; it will default to `ReactWPScripts`.
 
-
-Once installed, change your `start` script in `package.json` from
-
-```
-"start": "react-scripts start",
-```
-to
-```
-"start": "react-wp-scripts start",
-```
-
-Copy this code into your theme/plugin:
+Once installed, you can require this file from your theme or plugin code:
 ```php
 require __DIR__ . '/react-wp-scripts.php';
 
-function mytheme_enqueue_assets() {
+function myproject_enqueue_assets() {
+	// In a theme, pass in the stylesheet directory:
 	\ReactWPScripts\enqueue_assets( get_stylesheet_directory() );
+
+	// In a plugin, pass the plugin dir path:
+	\ReactWPScripts\enqueue_assets( plugin_dir_path( __FILE__ ) );
 }
-add_action( 'wp_enqueue_scripts', 'mytheme_enqueue_assets' );
+add_action( 'wp_enqueue_scripts', 'myproject_enqueue_assets' );
 ```
 
 This will load all generated JS and CSS into your theme or plugin.
 
-From now on, follow the common `react-scripts` [commands](https://github.com/facebookincubator/create-react-app/blob/master/README.md#npm-start-or-yarn-start)
+You may now use the `react-scripts` [commands](https://github.com/facebookincubator/create-react-app/blob/master/README.md#npm-start-or-yarn-start) as normal while you develop.
+
+## PHP Interface
 
 ### `enqueue_assets`
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A wrapper for create-react-app's `react-scripts` to allow seamless usage of scri
 From the root directory of your `create-react-app`-generated project, run
 
 ```sh
-npm install humanmade/react-wp-scripts
+npm install react-wp-scripts
 ```
 
 Once installed, change your `start` script in `package.json` from

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ A wrapper for create-react-app's [`react-scripts`](https://github.com/facebookin
 
 ## Installation & Usage
 
-Run `create-react-app --scripts-version react-wp-scripts /path/to/your/project/folder`
+Run `create-react-app --scripts-version react-wp-scripts --php-namespace="Your_Namespace" /path/to/your/project/folder`
+Replace `Your_Namespace` with any name you'd like to use for your PHP namespace. Default is `ReactWPScripts`
 
 A new `loader-react-scripts.php` will be created on your generated project folder.
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@ Run `create-react-app --scripts-version react-wp-scripts /path/to/your/project/f
 
 A new `loader-react-scripts.php` will be created on your generated project folder.
 
+
+Once installed, change your `start` script in `package.json` from
+
+```
+"start": "react-scripts start",
+```
+to
+```
+"start": "react-wp-scripts start",
+```
+
 Copy this code into your theme/plugin:
 ```php
 require __DIR__ . '/loader-react-scripts.php';

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A wrapper for create-react-app's [`react-scripts`](https://github.com/facebookin
 Run `create-react-app --scripts-version react-wp-scripts --php-namespace="Your_Namespace" /path/to/your/project/folder`
 Replace `Your_Namespace` with any name you'd like to use for your PHP namespace. Default is `ReactWPScripts`
 
-A new `loader-react-scripts.php` will be created on your generated project folder.
+A new `react-wp-scripts.php` will be created on your generated project folder.
 
 
 Once installed, change your `start` script in `package.json` from
@@ -24,7 +24,7 @@ to
 
 Copy this code into your theme/plugin:
 ```php
-require __DIR__ . '/loader-react-scripts.php';
+require __DIR__ . '/react-wp-scripts.php';
 
 function mytheme_enqueue_assets() {
 	\ReactWPScripts\enqueue_assets( get_stylesheet_directory() );

--- a/loader.php
+++ b/loader.php
@@ -3,7 +3,7 @@
  * Entrypoint for the theme.
  */
 
-namespace ReactWPScripts;
+namespace %%NAMESPACE%%;
 
 /**
  * Is this a development environment?

--- a/package.json
+++ b/package.json
@@ -1,26 +1,27 @@
 {
-	"name": "react-wp-scripts",
-	"description": "A wrapper for react-scripts to allow seamless usage of webpack-dev-server while developing a WordPress theme or plugin.",
-	"version": "0.1.1",
-	"contributors": [
-		"Ryan McCue",
-		"K. Adam White",
-		"Human Made"
-	],
-	"license": "GPL-2.0+",
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/humanmade/react-wp-scripts.git"
-	},
-	"bugs": {
-		"url": "https://github.com/humanmade/react-wp-scripts/issues"
-	},
-	"homepage": "https://github.com/humanmade/react-wp-scripts#readme",
-	"bin": {
-		"react-wp-scripts": "./bin/react-wp-scripts.js"
-	},
-	"dependencies": {
-		"react-scripts": "1.0.17",
-		"signal-exit": "^3.0.2"
-	}
+  "name": "react-wp-scripts",
+  "description": "A wrapper for react-scripts to allow seamless usage of webpack-dev-server while developing a WordPress theme or plugin.",
+  "version": "0.1.1",
+  "contributors": [
+    "Ryan McCue",
+    "K. Adam White",
+    "Human Made"
+  ],
+  "license": "GPL-2.0+",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/humanmade/react-wp-scripts.git"
+  },
+  "bugs": {
+    "url": "https://github.com/humanmade/react-wp-scripts/issues"
+  },
+  "homepage": "https://github.com/humanmade/react-wp-scripts#readme",
+  "bin": {
+    "react-wp-scripts": "./bin/react-wp-scripts.js"
+  },
+  "dependencies": {
+    "react-scripts": "1.0.17",
+    "signal-exit": "^3.0.2",
+    "uppercamelcase": "^3.0.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,11 @@
 	"name": "react-wp-scripts",
 	"description": "A wrapper for react-scripts to allow seamless usage of webpack-dev-server while developing a WordPress theme or plugin.",
 	"version": "0.1.0",
-	"contributors": [ "Ryan McCue", "K. Adam White", "Human Made" ],
+	"contributors": [
+		"Ryan McCue",
+		"K. Adam White",
+		"Human Made"
+	],
 	"license": "GPL-2.0+",
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "react-wp-scripts",
 	"description": "A wrapper for react-scripts to allow seamless usage of webpack-dev-server while developing a WordPress theme or plugin.",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"contributors": [
 		"Ryan McCue",
 		"K. Adam White",

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -60,23 +60,23 @@ module.exports = function(
 	const destinationFile = path.join( appPath, 'react-wp-scripts.php' );
 	fs.copy( loaderPath, destinationFile )
 		.then( () => {
-		// Replace %%NAMESPACE%% for the specified namespace
-		fs.readFile(destinationFile, 'utf8', function(err, data) {
-		if (err) {
-			console.log(err);
-		}
+			// Replace %%NAMESPACE%% for the specified namespace
+			fs.readFile( destinationFile, 'utf8', function( err, data ) {
+				if ( err ) {
+					console.log( err );
+				}
 
-		var result = data.replace('%%NAMESPACE%%',namespace);
-		fs.writeFile(destinationFile, result, 'utf8', function(err) {
-			if (err) {
-				return console.log(err);
-			};
-		});
-	});
-})
-.then( () => successMessage() )
-.catch( err => {
-		console.log( chalk.bgRed( 'React WP Scripts loader could not be copied to your root folder. Error details:' ) );
-	console.log( chalk.red( err ) );
-} );
+				var result = data.replace( '%%NAMESPACE%%', namespace );
+				fs.writeFile( destinationFile, result, 'utf8', function( err ) {
+					if ( err ) {
+						return console.log( err );
+					}
+				} );
+			} );
+		} )
+		.then( () => successMessage() )
+		.catch( err => {
+			console.log( chalk.bgRed( 'React WP Scripts loader could not be copied to your root folder. Error details:' ) );
+			console.log( chalk.red( err ) );
+		} );
 };

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -1,5 +1,16 @@
 'use strict';
 
+// Sets the start script for react-wp-scripts
+// And move the loader.php to the project root folder
+process.on( 'unhandledRejection', err => {
+	throw err;
+} );
+
+const fs = require( 'fs-extra' );
+const path = require( 'path' );
+const chalk = require( 'chalk' );
+const spawn = require( 'react-dev-utils/crossSpawn' );
+
 module.exports = function(
 	appPath,
 	appName,
@@ -7,16 +18,37 @@ module.exports = function(
 	originalDirectory,
 	template
 ) {
-	console.log("appPath");
-	console.log( appPath );
-	console.log("appName");
-	console.log( appName );
-	console.log("verbose");
-	console.log( verbose );
-	console.log("originalDirectory");
-	console.log( originalDirectory );
-	console.log("template");
-	console.log( template );
-	return;
+	const pkgName = require( path.join( __dirname, '..', 'package.json' ) ).name;
+	const reactWPScriptsPath = path.join( appPath, 'node_modules', pkgName );
+	const appPackage = require( path.join( appPath, 'package.json' ) );
+	const useYarn = fs.existsSync( path.join( appPath, 'yarn.lock' ) );
 
+	// Copy over some of the devDependencies
+	appPackage.dependencies = appPackage.dependencies || {};
+
+	// Setup the script rules
+	appPackage.scripts = {
+		start: 'react-wp-scripts start',
+	};
+
+	fs.writeFileSync(
+		path.join( appPath, 'package.json' ),
+		JSON.stringify( appPackage, null, 2 )
+	);
+
+	// Copy the loader.php
+	const loaderPath = path.join( reactWPScriptsPath, 'loader.php' );
+
+	function successMessage() {
+		console.log( chalk.green( 'React WP Scripts Loader copied to your project root folder.' ) );
+		console.log( chalk.green( 'Please, follow instructions to add PHP to enqueue your assets:' ) );
+		console.log( chalk.blue( 'https://github.com/humanmade/react-wp-scripts#react-wp-scripts' ) );
+	}
+
+	fs.copy( loaderPath, path.join( appPath, 'loader-react-scripts.php' ) )
+		.then( () => successMessage() )
+		.catch( err => {
+			console.log( chalk.bgRed( 'React WP Scripts loader could not be copied to your root folder. Error details:' ) );
+			console.log( chalk.red( err ) );
+		} );
 };

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -9,6 +9,14 @@ process.on( 'unhandledRejection', err => {
 const fs = require( 'fs-extra' );
 const path = require( 'path' );
 const chalk = require( 'chalk' );
+const commander = require('commander');
+const packageJson = require('../package.json');
+
+const program = new commander.Command( packageJson.name )
+	.version( packageJson.version )
+	.option( '--php-namespace [namespace]', 'Specify a namespace. Default: ReactWPScripts' )
+	.parse( process.argv );
+
 
 module.exports = function(
 	appPath,
@@ -17,6 +25,7 @@ module.exports = function(
 	originalDirectory,
 	template
 ) {
+	const namespace = program.phpNamespace ? program.phpNamespace : 'ReactWPScripts';
 	const pkgName = require( path.join( __dirname, '..', 'package.json' ) ).name;
 	const reactWPScriptsPath = path.join( appPath, 'node_modules', pkgName );
 	const appPackage = require( path.join( appPath, 'package.json' ) );
@@ -48,10 +57,26 @@ module.exports = function(
 		console.log( chalk.blue( 'https://github.com/humanmade/react-wp-scripts#react-wp-scripts' ) );
 	}
 
-	fs.copy( loaderPath, path.join( appPath, 'react-wp-scripts.php' ) )
-		.then( () => successMessage() )
-		.catch( err => {
-			console.log( chalk.bgRed( 'React WP Scripts loader could not be copied to your root folder. Error details:' ) );
-			console.log( chalk.red( err ) );
-		} );
+	const destinationFile = path.join( appPath, 'react-wp-scripts.php' );
+	fs.copy( loaderPath, destinationFile )
+		.then( () => {
+		// Replace %%NAMESPACE%% for the specified namespace
+		fs.readFile(destinationFile, 'utf8', function(err, data) {
+		if (err) {
+			console.log(err);
+		}
+
+		var result = data.replace('%%NAMESPACE%%',namespace);
+		fs.writeFile(destinationFile, result, 'utf8', function(err) {
+			if (err) {
+				return console.log(err);
+			};
+		});
+	});
+})
+.then( () => successMessage() )
+.catch( err => {
+		console.log( chalk.bgRed( 'React WP Scripts loader could not be copied to your root folder. Error details:' ) );
+	console.log( chalk.red( err ) );
+} );
 };

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -11,22 +11,28 @@ const path = require( 'path' );
 const chalk = require( 'chalk' );
 
 module.exports = function(
-	appPath
+	appPath,
+	appName,
+	verbose,
+	originalDirectory,
+	template
 ) {
 	const pkgName = require( path.join( __dirname, '..', 'package.json' ) ).name;
 	const reactWPScriptsPath = path.join( appPath, 'node_modules', pkgName );
 	const appPackage = require( path.join( appPath, 'package.json' ) );
 
-	// Copy over some of the devDependencies
-	appPackage.dependencies = appPackage.dependencies || {};
+	const scriptsPath = path.resolve(
+		process.cwd(),
+		'node_modules',
+		'react-scripts',
+		'scripts',
+		'init.js'
+	);
+	const reactScriptsInit = require(scriptsPath);
+	reactScriptsInit( appPath, appName, verbose, originalDirectory, template );
 
-	// Setup the script rules
-	appPackage.scripts = {
-		start: 'react-wp-scripts start',
-		build: 'react-scripts build',
-		test: 'react-scripts test --env=jsdom',
-		eject: 'react-scripts eject',
-	};
+	// Setup the custom start script
+	appPackage.scripts.start = 'react-wp-scripts start';
 
 	fs.writeFileSync(
 		path.join( appPath, 'package.json' ),

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -9,19 +9,13 @@ process.on( 'unhandledRejection', err => {
 const fs = require( 'fs-extra' );
 const path = require( 'path' );
 const chalk = require( 'chalk' );
-const spawn = require( 'react-dev-utils/crossSpawn' );
 
 module.exports = function(
 	appPath,
-	appName,
-	verbose,
-	originalDirectory,
-	template
 ) {
 	const pkgName = require( path.join( __dirname, '..', 'package.json' ) ).name;
 	const reactWPScriptsPath = path.join( appPath, 'node_modules', pkgName );
 	const appPackage = require( path.join( appPath, 'package.json' ) );
-	const useYarn = fs.existsSync( path.join( appPath, 'yarn.lock' ) );
 
 	// Copy over some of the devDependencies
 	appPackage.dependencies = appPackage.dependencies || {};

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -23,6 +23,9 @@ module.exports = function(
 	// Setup the script rules
 	appPackage.scripts = {
 		start: 'react-wp-scripts start',
+		build: 'react-scripts build',
+		test: 'react-scripts test --env=jsdom',
+		eject: 'react-scripts eject',
 	};
 
 	fs.writeFileSync(

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -9,14 +9,7 @@ process.on( 'unhandledRejection', err => {
 const fs = require( 'fs-extra' );
 const path = require( 'path' );
 const chalk = require( 'chalk' );
-const commander = require('commander');
-const packageJson = require('../package.json');
-
-const program = new commander.Command( packageJson.name )
-	.version( packageJson.version )
-	.option( '--php-namespace [namespace]', 'Specify a namespace. Default: ReactWPScripts' )
-	.parse( process.argv );
-
+const upperCamelCase = require( 'uppercamelcase' );
 
 module.exports = function(
 	appPath,
@@ -25,7 +18,15 @@ module.exports = function(
 	originalDirectory,
 	template
 ) {
-	const namespace = program.phpNamespace ? program.phpNamespace : 'ReactWPScripts';
+
+	// Parse a namespace based on the name of the package
+	let namespace = 'ReactWPScripts';
+	try {
+		const projectPackageJSON = require( path.join( process.cwd(), 'package.json' ) );
+		namespace = upperCamelCase( projectPackageJSON.name );
+	}
+	catch ( err ) {}
+
 	const pkgName = require( path.join( __dirname, '..', 'package.json' ) ).name;
 	const reactWPScriptsPath = path.join( appPath, 'node_modules', pkgName );
 	const appPackage = require( path.join( appPath, 'package.json' ) );

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -11,7 +11,7 @@ const path = require( 'path' );
 const chalk = require( 'chalk' );
 
 module.exports = function(
-	appPath,
+	appPath
 ) {
 	const pkgName = require( path.join( __dirname, '..', 'package.json' ) ).name;
 	const reactWPScriptsPath = path.join( appPath, 'node_modules', pkgName );

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -1,0 +1,1 @@
+console.log( "THIS IS A TEST" );

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -48,7 +48,7 @@ module.exports = function(
 		console.log( chalk.blue( 'https://github.com/humanmade/react-wp-scripts#react-wp-scripts' ) );
 	}
 
-	fs.copy( loaderPath, path.join( appPath, 'loader-react-scripts.php' ) )
+	fs.copy( loaderPath, path.join( appPath, 'react-wp-scripts.php' ) )
 		.then( () => successMessage() )
 		.catch( err => {
 			console.log( chalk.bgRed( 'React WP Scripts loader could not be copied to your root folder. Error details:' ) );

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -1,1 +1,22 @@
-console.log( "THIS IS A TEST" );
+'use strict';
+
+module.exports = function(
+	appPath,
+	appName,
+	verbose,
+	originalDirectory,
+	template
+) {
+	console.log("appPath");
+	console.log( appPath );
+	console.log("appName");
+	console.log( appName );
+	console.log("verbose");
+	console.log( verbose );
+	console.log("originalDirectory");
+	console.log( originalDirectory );
+	console.log("template");
+	console.log( template );
+	return;
+
+};


### PR DESCRIPTION
Issue: https://github.com/humanmade/react-wp-scripts/issues/12

The new `scripts/init.js` script...
- Replace the default `npm start` script for the custom `react-wp-scripts start`
- Copy `loader.php` to the project root folder.

To make things easier, this PR can be tested by running:
`create-react-app --scripts-version git+https://git@github.com/humanmade/react-wp-scripts.git#12-scripts-version-compatibility .`

If you want to play more without installing it over and over, create a JS, for instance `init-debug.js` in the project root folder with the following content:
```node
const init = require( 'react-wp-scripts/scripts/init.js' );
init( PATH_TO_PROJECT_ROOT_FOLDER );
```

And execute `node ./init-debug.js`. This will execute `scripts/init.js`.