### PR TITLE
Prevent Fatal error: Cannot redeclare...

### DIFF
--- a/loader.php
+++ b/loader.php
@@ -5,6 +5,11 @@
 
 namespace ReactWPScripts;
 
+// Prevent fatal error in case multiple plugins and/or themes make use of this.
+if ( function_exists( __NAMESPACE__ . '\\enqueue_assets' ) ) {
+	return;
+}
+
 /**
  * Is this a development environment?
  *


### PR DESCRIPTION
We suggest to copy the file into plugins or themes. With multiple plugins and/or themes using `react-wp-scripts`, this will result in a fatal error, though.

In order for people not having to write some kind of _include guard_, we should add this to the file itself.

This is what this PR is about.