### PR TITLE
Fix infer_base_url().

### DIFF
--- a/loader.php
+++ b/loader.php
@@ -68,14 +68,14 @@ function get_assets_list( string $directory ) {
  * @return string|null
  */
 function infer_base_url( string $path ) {
-	$path = str_replace( '\\', '/', $path );
+	$path = wp_normalize_path( $path );
 
-	$stylesheet_directory = str_replace( '\\', '/', get_stylesheet_directory() );
+	$stylesheet_directory = wp_normalize_path( get_stylesheet_directory() );
 	if ( strpos( $path, $stylesheet_directory ) === 0 ) {
 		return get_theme_file_uri( substr( $path, strlen( $stylesheet_directory ) ) );
 	}
 
-	$template_directory = str_replace( '\\', '/', get_template_directory() );
+	$template_directory = wp_normalize_path( get_template_directory() );
 	if ( strpos( $path, $template_directory ) === 0 ) {
 		return get_theme_file_uri( substr( $path, strlen( $template_directory ) ) );
 	}
@@ -83,7 +83,7 @@ function infer_base_url( string $path ) {
 	// Any path not known to exist within a theme is treated as a plugin path.
 	$plugin_path = get_plugin_basedir_path();
 	if ( strpos( $path, $plugin_path ) === 0 ) {
-		return plugin_dir_url( __FILE__ ) . substr( $path, strlen( $plugin_path ) );
+		return plugin_dir_url( __FILE__ ) . ltrim( substr( $path, strlen( $plugin_path ) ), '/' );
 	}
 
 	return '';
@@ -95,9 +95,9 @@ function infer_base_url( string $path ) {
  * @return string
  */
 function get_plugin_basedir_path() {
-	$plugin_dir_path = str_replace( '\\', '/', plugin_dir_path( __FILE__ ) );
+	$plugin_dir_path = wp_normalize_path( plugin_dir_path( __FILE__ ) );
 
-	$plugins_dir_path = str_replace( '\\', '/', trailingslashit( WP_PLUGIN_DIR ) );
+	$plugins_dir_path = wp_normalize_path( trailingslashit( WP_PLUGIN_DIR ) );
 
 	return substr( $plugin_dir_path, 0, strpos( $plugin_dir_path, '/', strlen( $plugins_dir_path ) + 1 ) );
 }

--- a/loader.php
+++ b/loader.php
@@ -83,7 +83,7 @@ function infer_base_url( string $path ) {
 	// Any path not known to exist within a theme is treated as a plugin path.
 	$plugin_path = get_plugin_basedir_path();
 	if ( strpos( $path, $plugin_path ) === 0 ) {
-		return plugin_dir_url( __FILE__ ) . ltrim( substr( $path, strlen( $plugin_path ) ), '/' );
+		return plugin_dir_url( __FILE__ ) . substr( $path, strlen( $plugin_path ) + 1 );
 	}
 
 	return '';

--- a/loader.php
+++ b/loader.php
@@ -68,21 +68,38 @@ function get_assets_list( string $directory ) {
  * @return string|null
  */
 function infer_base_url( string $path ) {
-	if ( strpos( $path, get_stylesheet_directory() ) === 0 ) {
-		return get_theme_file_uri( substr( $path, strlen( get_stylesheet_directory() ) ) );
+	$path = str_replace( '\\', '/', $path );
+
+	$stylesheet_directory = str_replace( '\\', '/', get_stylesheet_directory() );
+	if ( strpos( $path, $stylesheet_directory ) === 0 ) {
+		return get_theme_file_uri( substr( $path, strlen( $stylesheet_directory ) ) );
 	}
 
-	if ( strpos( $path, get_template_directory() ) === 0 ) {
-		return get_theme_file_uri( substr( $path, strlen( get_template_directory() ) ) );
+	$template_directory = str_replace( '\\', '/', get_template_directory() );
+	if ( strpos( $path, $template_directory ) === 0 ) {
+		return get_theme_file_uri( substr( $path, strlen( $template_directory ) ) );
 	}
 
 	// Any path not known to exist within a theme is treated as a plugin path.
-	$plugin_path = plugin_dir_path( __FILE__ );
+	$plugin_path = get_plugin_basedir_path();
 	if ( strpos( $path, $plugin_path ) === 0 ) {
 		return plugin_dir_url( __FILE__ ) . substr( $path, strlen( $plugin_path ) );
 	}
 
 	return '';
+}
+
+/**
+ * Return the path of the plugin basedir.
+ *
+ * @return string
+ */
+function get_plugin_basedir_path() {
+	$plugin_dir_path = str_replace( '\\', '/', plugin_dir_path( __FILE__ ) );
+
+	$plugins_dir_path = str_replace( '\\', '/', trailingslashit( WP_PLUGIN_DIR ) );
+
+	return substr( $plugin_dir_path, 0, strpos( $plugin_dir_path, '/', strlen( $plugins_dir_path ) + 1 ) );
 }
 
 /**


### PR DESCRIPTION
The `infer_base_url` function includes two defects:

* it doesn't work at all on Windows;
* it only works when the `loader.php` file lives in the plugin root.

This pull requests addresses both of the above issues.

**Windows**  
When doing string search and/or replacement, we have to normalize the directory separators. We are used to linux (i.e., a forward slash, `/`), and we also generate URLs, so this pull request converts any backslash to a forward slash.

**`loader.php` Location**  
For a simple plugin that I am working on right now, I didn't want the `loader.php` file to live in the plugin root. Instead, I copied it to `vendor/humanmade/react-wp-scripts`, and also used Composer to autoload the file.
Now, the current logic of the `infer_base_url` function expects the `loader.php` file to live in the root. This pull request makes it possible to move the `loader.php` to any location inside a plugin.

Opinions?