### PR TITLE
add prefix to default handle to avoid conflicts

### DIFF
--- a/loader.php
+++ b/loader.php
@@ -129,7 +129,7 @@ function get_asset_uri( string $asset_path, string $base_url ) {
 function enqueue_assets( $directory, $opts = [] ) {
 	$defaults = [
 		'base_url' => '',
-		'handle'   => basename( $directory ),
+		'handle'   => 'rwps' . basename( $directory ),
 		'scripts'  => [],
 		'styles'   => [],
 	];


### PR DESCRIPTION
My react directory was called "editor", which conflicted with a built in enqueued asset. Added a prefix to the default handle so these will be unique.