### PR TITLE
Use a Promise wrapper for fs actions and minimist for argv parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "chalk": "^2.3.2",
     "minimist": "^1.2.0",
     "react-scripts": "1.0.17",
-    "signal-exit": "^3.0.2",
-    "uppercamelcase": "^3.0.0"
+    "signal-exit": "^3.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "chalk": "^2.3.2",
+    "minimist": "^1.2.0",
     "react-scripts": "1.0.17",
     "signal-exit": "^3.0.2",
     "uppercamelcase": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react-wp-scripts": "./bin/react-wp-scripts.js"
   },
   "dependencies": {
+    "chalk": "^2.3.2",
     "react-scripts": "1.0.17",
     "signal-exit": "^3.0.2",
     "uppercamelcase": "^3.0.0"

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -11,7 +11,8 @@ process.on( 'unhandledRejection', err => {
 const fs = require( 'fs-extra' );
 const path = require( 'path' );
 const chalk = require( 'chalk' );
-const upperCamelCase = require( 'uppercamelcase' );
+
+const argv = require( 'minimist' )( process.argv.slice( 2 ) );
 
 module.exports = function(
 	appPath,
@@ -22,12 +23,7 @@ module.exports = function(
 ) {
 
 	// Parse a namespace based on the name of the package
-	let namespace = 'ReactWPScripts';
-	try {
-		const projectPackageJSON = require( path.join( process.cwd(), 'package.json' ) );
-		namespace = upperCamelCase( projectPackageJSON.name );
-	}
-	catch ( err ) {}
+	let namespace = argv['php-namespace'] || 'ReactWPScripts';
 
 	const pkgName = require( path.join( __dirname, '..', 'package.json' ) ).name;
 	const reactWPScriptsPath = path.join( appPath, 'node_modules', pkgName );

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -1,7 +1,9 @@
+/**
+ * Sets the start script for react-wp-scripts and moves
+ * loader.php to the project root folder.
+ */
 'use strict';
 
-// Sets the start script for react-wp-scripts
-// And move the loader.php to the project root folder
 process.on( 'unhandledRejection', err => {
 	throw err;
 } );
@@ -52,30 +54,29 @@ module.exports = function(
 	// Copy the loader.php
 	const loaderPath = path.join( reactWPScriptsPath, 'loader.php' );
 
-	function successMessage() {
-		console.log( chalk.green( 'React WP Scripts Loader copied to your project root folder.' ) );
-		console.log( chalk.green( 'Please, follow instructions to add PHP to enqueue your assets:' ) );
-		console.log( chalk.blue( 'https://github.com/humanmade/react-wp-scripts#react-wp-scripts' ) );
-	}
-
 	const destinationFile = path.join( appPath, 'react-wp-scripts.php' );
 	fs.copy( loaderPath, destinationFile )
-		.then( () => {
+		.then( () => new Promise( ( resolve, reject ) => {
 			// Replace %%NAMESPACE%% for the specified namespace
 			fs.readFile( destinationFile, 'utf8', function( err, data ) {
 				if ( err ) {
-					console.log( err );
+					return reject( err );
 				}
 
 				var result = data.replace( '%%NAMESPACE%%', namespace );
 				fs.writeFile( destinationFile, result, 'utf8', function( err ) {
 					if ( err ) {
-						return console.log( err );
+						return reject( err );
 					}
+					resolve();
 				} );
 			} );
+		} ) )
+		.then( () => {
+			console.log( chalk.green( 'React WP Scripts Loader copied to your project root folder.' ) );
+			console.log( chalk.green( 'Please follow these instructions to enqueue your assets in PHP:' ) );
+			console.log( chalk.blue( 'https://github.com/humanmade/react-wp-scripts#react-wp-scripts' ) );
 		} )
-		.then( () => successMessage() )
 		.catch( err => {
 			console.log( chalk.bgRed( 'React WP Scripts loader could not be copied to your root folder. Error details:' ) );
 			console.log( chalk.red( err ) );

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -23,7 +23,7 @@ module.exports = function(
 ) {
 
 	// Parse a namespace based on the name of the package
-	let namespace = argv['php-namespace'] || 'ReactWPScripts';
+	const namespace = argv['php-namespace'] || 'ReactWPScripts';
 
 	const pkgName = require( path.join( __dirname, '..', 'package.json' ) ).name;
 	const reactWPScriptsPath = path.join( appPath, 'node_modules', pkgName );


### PR DESCRIPTION
This PR (which is PR'd **against #15**, not against master) proposes some final changes to #15 based on my review comments there.

- Wrap callback-based `fs` actions in a ¶romise to ensure that action completes before we report success
- Add `chalk` to project dependencies
- Revert the change to auto-generating the script loader namespace from the project directory, in favor of using the `--php-namespace` command-line argument

To test, run
```
npx create-react-app --scripts-version git+https://git@github.com/humanmade/react-wp-scripts.git#12-init-proposed-changes --php-namespace DemoNamespace demo-wpscripts-plugin
```