### PR TITLE
Fix hot loading

### DIFF
--- a/overrides/webpackHotDevClient.js
+++ b/overrides/webpackHotDevClient.js
@@ -4,6 +4,9 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+// <REACT-WP-SCRIPTS>
+// Sections below modified from react-scripts to serve cross-domain.
+// </REACT-WP-SCRIPTS>
 
 'use strict';
 
@@ -57,6 +60,9 @@ if (module.hot && typeof module.hot.dispose === 'function') {
 	});
 }
 
+// <REACT-WP-SCRIPTS>
+// Replace connection creation to allow using the script's domain
+// (localhost:3000) rather than the web root.
 function getCurrentScriptSource() {
 	// `document.currentScript` is the most accurate way to find the current script,
 	// but is not supported in all browsers.
@@ -81,6 +87,7 @@ var connection = new SockJS(
 		pathname: '/sockjs-node',
 	})
 );
+// </REACT-WP-SCRIPTS>
 
 // Unlike WebpackDevServer client, we won't try to reconnect
 // to avoid spamming the console. Disconnect usually happens

--- a/overrides/webpackHotDevClient.js
+++ b/overrides/webpackHotDevClient.js
@@ -30,7 +30,9 @@ ErrorOverlay.setEditorHandler(function editorHandler(errorLocation) {
 			'?fileName=' +
 			window.encodeURIComponent(errorLocation.fileName) +
 			'&lineNumber=' +
-			window.encodeURIComponent(errorLocation.lineNumber || 1)
+			window.encodeURIComponent(errorLocation.lineNumber || 1) +
+			'&colNumber=' +
+			window.encodeURIComponent(errorLocation.colNumber || 1)
 	);
 });
 
@@ -39,7 +41,7 @@ ErrorOverlay.setEditorHandler(function editorHandler(errorLocation) {
 // runtime error. To prevent confusing behavior, we forcibly reload the entire
 // application. This is handled below when we are notified of a compile (code
 // change).
-// See https://github.com/facebookincubator/create-react-app/issues/3096
+// See https://github.com/facebook/create-react-app/issues/3096
 var hadRuntimeError = false;
 ErrorOverlay.startReportingRuntimeErrors({
 	onError: function() {

--- a/scripts/override-start.js
+++ b/scripts/override-start.js
@@ -35,7 +35,12 @@ const overrideWebpackConfig = ( config, devServer ) => {
 
 	// Replace the react-dev-utils webpackHotDevClient with a version patched to
 	// correctly detect the dev server host & port for socket requests.
-	const hotClient = require.resolve( 'react-dev-utils/webpackHotDevClient' );
+	const hotClient = require.resolve( 'react-dev-utils/webpackHotDevClient', {
+		paths: [
+			// Resolve relative to the original config.
+			devConfig,
+		],
+	} );
 
 	if ( Array.isArray( config.entry ) ) {
 		const hotClientIndex = config.entry.indexOf( hotClient );


### PR DESCRIPTION
When modules aren't hoisted, `webpackHotDevClient` is in `node_modules/react-scripts/node_modules/react-dev-utils`, so we need to resolve relative to the original loaded file.

While I was there, I incorporated the changes to the latest hot client from upstream, and annotated modifications for ease of use next time around.

Fixes #69.